### PR TITLE
chore: go-demo-6 to 4.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.89
+- name: go-demo-6
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 4.0.8
 - name: jx-k8s-days-go-01
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
chore: Promote go-demo-6 to version 4.0.8